### PR TITLE
Keep Order feature

### DIFF
--- a/core/src/main/java/net/adamcin/recap/api/RecapConstants.java
+++ b/core/src/main/java/net/adamcin/recap/api/RecapConstants.java
@@ -69,6 +69,7 @@ public final class RecapConstants {
     // ------------------------------------------------
     public static final String RP_UPDATE = ":update";
     public static final String RP_ONLY_NEWER = ":only_newer";
+    public static final String RP_KEEP_ORDER = ":keep_order";
     public static final String RP_REVERSE = ":reverse";
     public static final String RP_NO_RECURSE = ":no_recurse";
     public static final String RP_NO_DELETE = ":no_delete";

--- a/core/src/main/java/net/adamcin/recap/api/RecapOptions.java
+++ b/core/src/main/java/net/adamcin/recap/api/RecapOptions.java
@@ -52,4 +52,6 @@ public interface RecapOptions {
     boolean isNoRecurse();
 
     boolean isNoDelete();
+
+    boolean isKeepOrder();
 }

--- a/core/src/main/java/net/adamcin/recap/api/RecapProgressListener.java
+++ b/core/src/main/java/net/adamcin/recap/api/RecapProgressListener.java
@@ -42,7 +42,7 @@ public interface RecapProgressListener {
     void onPath(PathAction action, int count, String path);
 
     enum PathAction {
-        ADD("A"), UPDATE("U"), DELETE("D"), IGNORE("I"), NO_ACTION("-");
+        ADD("A"), UPDATE("U"), DELETE("D"), MOVE("M"), IGNORE("I"), NO_ACTION("-");
 
         String action;
         PathAction(String action) {

--- a/core/src/main/java/net/adamcin/recap/impl/RecapAdapterFactory.java
+++ b/core/src/main/java/net/adamcin/recap/impl/RecapAdapterFactory.java
@@ -176,6 +176,10 @@ public class RecapAdapterFactory implements AdapterFactory {
             options.setNoDelete(true);
         }
 
+        if ("true".equals(request.getParameter(RecapConstants.RP_KEEP_ORDER))) {
+            options.setKeepOrder(true);
+        }
+
         String rpBatchSize = request.getParameter(RecapConstants.RP_BATCH_SIZE);
         if (StringUtils.isNotBlank(rpBatchSize)) {
             try {

--- a/core/src/main/java/net/adamcin/recap/impl/RecapImpl.java
+++ b/core/src/main/java/net/adamcin/recap/impl/RecapImpl.java
@@ -247,6 +247,7 @@ public class RecapImpl implements Recap, RecapSessionInterrupter {
             dOptions.setReverse(options.isReverse());
             dOptions.setNoRecurse(options.isNoRecurse());
             dOptions.setNoDelete(options.isNoDelete());
+            dOptions.setKeepOrder(options.isKeepOrder());
             if (options.getThrottle() != null) {
                 dOptions.setThrottle(options.getThrottle());
             }

--- a/core/src/main/java/net/adamcin/recap/impl/RecapOptionsImpl.java
+++ b/core/src/main/java/net/adamcin/recap/impl/RecapOptionsImpl.java
@@ -47,6 +47,7 @@ public class RecapOptionsImpl extends DefaultRecapOptions {
     private boolean reverse;
     private boolean noRecurse;
     private boolean noDelete;
+    private boolean keepOrder;
 
     public String getLastModifiedProperty() {
         return lastModifiedProperty;
@@ -128,6 +129,14 @@ public class RecapOptionsImpl extends DefaultRecapOptions {
         this.noDelete = noDelete;
     }
 
+    public boolean isKeepOrder() {
+        return keepOrder;
+    }
+
+    public void setKeepOrder(boolean keepOrder) {
+        this.keepOrder = keepOrder;
+    }
+
     @Override
     public String toString() {
         return "RecapOptionsImpl{" +
@@ -136,6 +145,7 @@ public class RecapOptionsImpl extends DefaultRecapOptions {
                 ", throttle=" + throttle +
                 ", requestDepthConfig=" + requestDepthConfig +
                 ", onlyNewer=" + onlyNewer +
+                ", keepOrder=" + keepOrder +
                 ", update=" + update +
                 ", reverse=" + reverse +
                 ", noRecurse=" + noRecurse +

--- a/core/src/main/java/net/adamcin/recap/util/DefaultRecapOptions.java
+++ b/core/src/main/java/net/adamcin/recap/util/DefaultRecapOptions.java
@@ -72,4 +72,8 @@ public class DefaultRecapOptions implements RecapOptions {
     public boolean isNoDelete() {
         return false;
     }
+
+    public boolean isKeepOrder() {
+        return false;
+    }
 }

--- a/core/src/main/java/net/adamcin/recap/util/OrderableNodesList.java
+++ b/core/src/main/java/net/adamcin/recap/util/OrderableNodesList.java
@@ -1,0 +1,56 @@
+package net.adamcin.recap.util;
+
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+
+public class OrderableNodesList implements Iterable<String> {
+    private Node parent;
+    private List<String> nodes;
+
+    public OrderableNodesList(Node parent) throws RepositoryException {
+        this.parent = parent;
+        this.nodes = new ArrayList<String>();
+        buildList();
+    }
+
+    private void buildList() throws RepositoryException {
+        NodeIterator nodeIterator = parent.getNodes();
+        while (nodeIterator.hasNext()) {
+            nodes.add(nodeIterator.nextNode().getName());
+        }
+    }
+
+    public void moveExistingNode(String nodeName, int pos) throws RepositoryException {
+        if (!nodes.contains(nodeName)) {
+            throw new NoSuchElementException("The node " + nodeName + " was not found under " + parent.getPath());
+        }
+
+        nodes.remove(nodeName);
+        String orderBeforeNodeName = pos < nodes.size() ? nodes.get(pos) : null;
+        parent.orderBefore(nodeName, orderBeforeNodeName);
+        nodes.add(pos, nodeName);
+    }
+
+    public int getPos(String nodeName) {
+        return nodes.indexOf(nodeName);
+    }
+
+    public boolean contains(String nodeName) {
+        return nodes.contains(nodeName);
+    }
+
+    public String getRepositoryPath(String nodeName) throws RepositoryException {
+        return nodes.contains(nodeName) ? parent.getNode(nodeName).getPath() : "";
+    }
+
+    public Iterator<String> iterator() {
+        return nodes.iterator();
+    }
+}

--- a/core/src/test/java/net/adamcin/recap/impl/RecapSessionImplTest.java
+++ b/core/src/test/java/net/adamcin/recap/impl/RecapSessionImplTest.java
@@ -311,8 +311,8 @@ public class RecapSessionImplTest {
                 session.setProgressListener(tracker);
                 session.sync("/" + BASIC_NODE_NAME);
 
-                NodeIterator remoteNi = REMOTE_ROOT.getNodes();
-                NodeIterator localNi = LOCAL_ROOT.getNodes();
+                NodeIterator remoteNi = remoteSession.getNode("/" + BASIC_NODE_NAME).getNodes();
+                NodeIterator localNi = localSession.getNode("/" + BASIC_NODE_NAME).getNodes();
                 while (remoteNi.hasNext()) {
                     assertTrue(remoteNi.nextNode().getName().equals(localNi.nextNode().getName()));
                 }

--- a/core/src/test/java/net/adamcin/recap/impl/RecapSessionImplTest.java
+++ b/core/src/test/java/net/adamcin/recap/impl/RecapSessionImplTest.java
@@ -39,10 +39,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.Credentials;
-import javax.jcr.Node;
-import javax.jcr.Session;
-import javax.jcr.SimpleCredentials;
+import javax.jcr.*;
 import java.io.File;
 
 import static org.junit.Assert.*;
@@ -269,6 +266,56 @@ public class RecapSessionImplTest {
                 assertEquals("number of synced paths should be", 1, session.getTotalSyncPaths());
                 assertEquals("total number of nodes should be", 20, session.getTotalNodes());
                 assertEquals("last synced path should be", "/basicDelete0", session.getLastSuccessfulSyncPath());
+            }
+        });
+    }
+
+    @Test
+    public void testNodeOrdering() {
+        TestBody.test(new RecapTestBody() {
+            @Override
+            protected void execute() throws Exception {
+                final String BASIC_NODE_NAME = "syncOrdered";
+                localSession = localRepo.login(DEFAULT_CREDENTIALS);
+                remoteSession = remoteRepo.login(DEFAULT_CREDENTIALS);
+
+                Node REMOTE_ROOT = remoteSession.getRootNode().addNode(BASIC_NODE_NAME, JcrConstants.NT_UNSTRUCTURED);
+                REMOTE_ROOT.addNode(BASIC_NODE_NAME + 1, JcrConstants.NT_UNSTRUCTURED);
+                REMOTE_ROOT.addNode(BASIC_NODE_NAME + 2, JcrConstants.NT_UNSTRUCTURED);
+                REMOTE_ROOT.addNode(BASIC_NODE_NAME + 3, JcrConstants.NT_UNSTRUCTURED);
+                REMOTE_ROOT.addNode(BASIC_NODE_NAME + 4, JcrConstants.NT_UNSTRUCTURED);
+                REMOTE_ROOT.addNode(BASIC_NODE_NAME + 5, JcrConstants.NT_UNSTRUCTURED);
+                REMOTE_ROOT.addNode(BASIC_NODE_NAME + 6, JcrConstants.NT_UNSTRUCTURED);
+                REMOTE_ROOT.getSession().save();
+
+                Node LOCAL_ROOT = localSession.getRootNode().addNode(BASIC_NODE_NAME, JcrConstants.NT_UNSTRUCTURED);
+                LOCAL_ROOT.addNode(BASIC_NODE_NAME + 1, JcrConstants.NT_UNSTRUCTURED);
+                LOCAL_ROOT.addNode(BASIC_NODE_NAME + 5, JcrConstants.NT_UNSTRUCTURED);
+                LOCAL_ROOT.addNode(BASIC_NODE_NAME + 2, JcrConstants.NT_UNSTRUCTURED);
+                LOCAL_ROOT.addNode(BASIC_NODE_NAME + 3, JcrConstants.NT_UNSTRUCTURED);
+                LOCAL_ROOT.addNode(BASIC_NODE_NAME + 4, JcrConstants.NT_UNSTRUCTURED);
+                LOCAL_ROOT.addNode(BASIC_NODE_NAME + 6, JcrConstants.NT_UNSTRUCTURED);
+                LOCAL_ROOT.getSession().save();
+
+                TestProgressTracker tracker = new TestProgressTracker();
+                RecapSessionInterrupter interrupter = new TestInterrupter();
+                RecapOptionsImpl options = new RecapOptionsImpl();
+                options.setOnlyNewer(true);
+                options.setKeepOrder(true);
+                options.setUpdate(true);
+                RecapSessionImpl session = new RecapSessionImpl(interrupter,
+                        DEFAULT_ADDRESS,
+                        options,
+                        localSession,
+                        remoteSession);
+                session.setProgressListener(tracker);
+                session.sync("/" + BASIC_NODE_NAME);
+
+                NodeIterator remoteNi = REMOTE_ROOT.getNodes();
+                NodeIterator localNi = LOCAL_ROOT.getNodes();
+                while (remoteNi.hasNext()) {
+                    assertTrue(remoteNi.nextNode().getName().equals(localNi.nextNode().getName()));
+                }
             }
         });
     }

--- a/graniteui/src/main/content/jcr_root/components/addressbook/address/html.GET.jsp
+++ b/graniteui/src/main/content/jcr_root/components/addressbook/address/html.GET.jsp
@@ -112,6 +112,12 @@
                         <p class="ui-input-desc" data-for="${pageId}-onlyNewer">
                             If checked, existing nodes will only be updated if the source node is marked as newer than the target node.
                         </p>
+                        <label for="${pageId}-keepOrder">Keep order of nodes</label>
+                        <input id="${pageId}-keepOrder" type="checkbox" value="true"
+                               name="<%=RecapConstants.RP_KEEP_ORDER %>"/>
+                        <p class="ui-input-desc" data-for="${pageId}-keepOrder">
+                            If checked, the order of nodes in target repository will match the source.
+                        </p>
                         <label for="${pageId}-noRecurse">Non-Recursive</label>
                         <input id="${pageId}-noRecurse" type="checkbox" value="true"
                                name="<%=RecapConstants.RP_NO_RECURSE %>"/>

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,52 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>adobe-public</id>
+
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <properties>
+                <releaseRepository-Id>adobe-public-releases</releaseRepository-Id>
+                <releaseRepository-Name>Adobe Public Releases</releaseRepository-Name>
+                <releaseRepository-URL>http://repo.adobe.com/nexus/content/groups/public</releaseRepository-URL>
+            </properties>
+
+            <repositories>
+                <repository>
+                    <id>adobe-public-releases</id>
+                    <name>Adobe Public Repository</name>
+                    <url>http://repo.adobe.com/nexus/content/groups/public</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>adobe-public-releases</id>
+                    <name>Adobe Public Repository</name>
+                    <url>http://repo.adobe.com/nexus/content/groups/public</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+
     <reporting>
         <plugins>
             <plugin>


### PR DESCRIPTION
Introducing the new feature aimed to mirror the order of nodes in target repository from source while synchronizing content. Currently Recap syncs content in terms of data ignoring the order of child nodes, but such behavior is very important especially for cq:PageContent nodes. The feature is optional, please see screenshot below:
![keep_order_feature](https://cloud.githubusercontent.com/assets/12492648/11685731/46631dc2-9e8c-11e5-93a7-e6e0dfb25f37.png)

Please accept my pull request.

Thank You!
Best Regards,
Yuriy Rastorguev